### PR TITLE
Require dependencies directly instead of relying on sub-dependencies

### DIFF
--- a/lib/js-client/index.js
+++ b/lib/js-client/index.js
@@ -1,6 +1,6 @@
 var camelCase, context, defaultHelpers, extend, generator, helpers, languages;
 
-extend = require('raml-client-generator/node_modules/extend');
+extend = require('extend');
 
 languages = require('raml-client-generator/languages');
 
@@ -18,7 +18,7 @@ generator.partials = {
 };
 
 helpers = {
-  stringify: require('raml-client-generator/node_modules/javascript-stringify'),
+  stringify: require('javascript-stringify'),
   dependencies: require('raml-client-generator/languages/javascript/helpers/dependencies'),
   requestSnippet: require('raml-client-generator/languages/javascript/helpers/request-snippet'),
   parametersSnippet: require('raml-client-generator/languages/javascript/helpers/parameters-snippet')
@@ -36,7 +36,7 @@ generator.templates = [
   }
 ];
 
-camelCase = require('raml-client-generator/node_modules/camel-case');
+camelCase = require('camel-case');
 
 generator.parser = function(data) {
   var model, parsed, spec, version;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "run-sequence": "^1.0.2"
   },
   "dependencies": {
-    "raml-client-generator" : "0.0.6"
+    "camel-case": "^1.2.0",
+    "extend": "^3.0.0",
+    "javascript-stringify": "^1.0.1",
+    "raml-client-generator": "0.0.6"
   }
 }

--- a/src/js-client/index.coffee
+++ b/src/js-client/index.coffee
@@ -1,4 +1,4 @@
-extend  = require('raml-client-generator/node_modules/extend');
+extend  = require('extend');
 languages  = require('raml-client-generator/languages');
 context = require('raml-client-generator/lib/compile/context');
 
@@ -13,7 +13,7 @@ generator.partials = {
 }
 
 helpers = {
-  stringify:         require('raml-client-generator/node_modules/javascript-stringify'),
+  stringify:         require('javascript-stringify'),
   dependencies:      require('raml-client-generator/languages/javascript/helpers/dependencies'),
   requestSnippet:    require('raml-client-generator/languages/javascript/helpers/request-snippet'),
   parametersSnippet: require('raml-client-generator/languages/javascript/helpers/parameters-snippet')
@@ -29,7 +29,7 @@ generator.templates =  [
     require('raml-client-generator/languages/javascript/templates/README.md.hbs')}
 ]
 
-camelCase = require('raml-client-generator/node_modules/camel-case')
+camelCase = require('camel-case')
 
 generator.parser = (data) ->
   parsed = []

--- a/test/jsClient-spec.js
+++ b/test/jsClient-spec.js
@@ -14,6 +14,6 @@ describe('Must run on raml2code', function () {
   };
 
   it('should generate a js client from RAML file', gatitosAPI);
-  it('should generate a js client from RAML file', readme);
+  it('should generate a README.md from RAML file', readme);
 
 });


### PR DESCRIPTION
Some modules were not being correctly resolved when calling them through a dependency.
